### PR TITLE
Agummybear/add reset command

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-vectornav (2.0.0-bionic2) bionic; urgency=medium
+
+  * Added ability to reset IMU via ROS service call
+
+ -- David Jensen <david@greenzie.com>  Tue, 16 Mar 2021 15:47:18 -0400
+
 ros-melodic-vectornav (2.0.0-bionic1) bionic; urgency=medium
 
   * install libvncxx to ros debian folder

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 ros::Publisher pubIMU, pubMag, pubGPS, pubOdom, pubTemp, pubPres;
-ros::ServiceServer resetOdomSrv;
+ros::ServiceServer resetOdomSrv, resetImuSrv;
 
 //Unused covariances initilized to zero's
 boost::array<double, 9ul> linear_accel_covariance = { };
@@ -77,6 +77,8 @@ bool frame_based_enu;
 vec3d initial_position;
 bool initial_position_set = false;
 
+bool need_to_reset = false;
+
 // Basic loop so we can initilize our covariance parameters above
 boost::array<double, 9ul> setCov(XmlRpc::XmlRpcValue rpc){
     // Output covariance vector
@@ -99,6 +101,13 @@ bool resetOdom(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp)
     return true;
 }
 
+// Send a reset() command to the connected device
+bool resetImu(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp)
+{
+    need_to_reset = true;
+    return true;
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -115,6 +124,7 @@ int main(int argc, char *argv[])
     pubPres = n.advertise<sensor_msgs::FluidPressure>("vectornav/Pres", 1000);
 
     resetOdomSrv = n.advertiseService("reset_odom", resetOdom);
+    resetImuSrv = n.advertiseService("reset_vectornav_imu", resetImu);
 
     // Serial Port Settings
     string SensorPort;
@@ -248,9 +258,16 @@ int main(int argc, char *argv[])
     // You spin me right round, baby
     // Right round like a record, baby
     // Right round round round
+    ros::Rate loop_rate(10);
     while (ros::ok())
     {
-        ros::spin(); // Need to make sure we disconnect properly. Check if all ok.
+        if (need_to_reset)
+        {
+            bool wait_for_reply = true;
+            vs.reset(wait_for_reply);
+            need_to_reset = false;
+        }
+        ros::spinOnce(); // Need to make sure we disconnect properly. Check if all ok.
     }
 
     // Node has been terminated

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,9 +169,8 @@ int main(int argc, char *argv[])
         // Run through all of the acceptable baud rates until we are connected
         // Looping in case someone has changed the default
         bool baudSet = false;
+        int i = 0;
         while(!baudSet){
-            // Make this variable only accessible in the while loop
-            static int i = 0;
             defaultBaudrate = vs.supportedBaudrates()[i];
             ROS_INFO("Connecting with default at %d", defaultBaudrate);
             // Default response was too low and retransmit time was too long by default.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,122 +159,127 @@ int main(int argc, char *argv[])
 
     ROS_INFO("Connecting to : %s @ %d Baud", SensorPort.c_str(), SensorBaudrate);
 
-    // Create a VnSensor object and connect to sensor
-    VnSensor vs;
-
-    // Default baudrate variable
-    int defaultBaudrate;
-    // Run through all of the acceptable baud rates until we are connected
-    // Looping in case someone has changed the default
-    bool baudSet = false;
-    while(!baudSet){
-        // Make this variable only accessible in the while loop
-        static int i = 0;
-        defaultBaudrate = vs.supportedBaudrates()[i];
-        ROS_INFO("Connecting with default at %d", defaultBaudrate);
-        // Default response was too low and retransmit time was too long by default.
-        // They would cause errors
-        vs.setResponseTimeoutMs(1000); // Wait for up to 1000 ms for response
-        vs.setRetransmitDelayMs(50);  // Retransmit every 50 ms
-
-        // Acceptable baud rates 9600, 19200, 38400, 57600, 128000, 115200, 230400, 460800, 921600
-        // Data sheet says 128000 is a valid baud rate. It doesn't work with the VN100 so it is excluded.
-        // All other values seem to work fine.
-        try{
-            // Connect to sensor at it's default rate
-            if(defaultBaudrate != 128000 && SensorBaudrate != 128000)
-            {
-                vs.connect(SensorPort, defaultBaudrate);
-                // Issues a change baudrate to the VectorNav sensor and then
-                // reconnects the attached serial port at the new baudrate.
-                vs.changeBaudRate(SensorBaudrate);
-                // Only makes it here once we have the default correct
-                ROS_INFO("Connected baud rate is %d",vs.baudrate());
-                baudSet = true;
-            }
-        }
-        // Catch all oddities
-        catch(...){
-            // Disconnect if we had the wrong default and we were connected
-            vs.disconnect();
-            ros::Duration(0.2).sleep();
-        }
-        // Increment the default iterator
-        i++;
-        // There are only 9 available data rates, if no connection
-        // made yet possibly a hardware malfunction?
-        if(i > 8)
-        {
-            break;
-        }
-    }
-
-    // Now we verify connection (Should be good if we made it this far)
-    if(vs.verifySensorConnectivity())
-    {
-        ROS_INFO("Device connection established");
-    }else{
-        ROS_ERROR("No device communication");
-        ROS_WARN("Please input a valid baud rate. Valid are:");
-        ROS_WARN("9600, 19200, 38400, 57600, 115200, 128000, 230400, 460800, 921600");
-        ROS_WARN("With the test IMU 128000 did not work, all others worked fine.");
-    }
-    // Query the sensor's model number.
-    string mn = vs.readModelNumber();
-    ROS_INFO("Model Number: %s", mn.c_str());
-
-    // Set the device info for passing to the packet callback function
-    UserData user_data;
-    user_data.device_family = vs.determineDeviceFamily();
-
-    // Set Data output Freq [Hz]
-    vs.writeAsyncDataOutputFrequency(async_output_rate);
-
-    // Configure binary output message
-    BinaryOutputRegister bor(
-            ASYNCMODE_PORT1,
-            SensorImuRate / async_output_rate,  // update rate [ms]
-            COMMONGROUP_QUATERNION
-            | COMMONGROUP_ANGULARRATE
-            | COMMONGROUP_POSITION
-            | COMMONGROUP_ACCEL
-            | COMMONGROUP_MAGPRES,
-            TIMEGROUP_NONE,
-            IMUGROUP_NONE,
-            GPSGROUP_NONE,
-            ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
-            INSGROUP_INSSTATUS
-            | INSGROUP_POSLLA
-            | INSGROUP_POSECEF
-            | INSGROUP_VELBODY
-            | INSGROUP_ACCELECEF);
-
-    vs.writeBinaryOutput1(bor);
-
-    // Set Data output Freq [Hz]
-    vs.writeAsyncDataOutputFrequency(async_output_rate);
-    vs.registerAsyncPacketReceivedHandler(&user_data, BinaryAsyncMessageReceived);
-
-    // You spin me right round, baby
-    // Right round like a record, baby
-    // Right round round round
-    ros::Rate loop_rate(10);
     while (ros::ok())
     {
-        if (need_to_reset)
-        {
-            bool wait_for_reply = true;
-            vs.reset(wait_for_reply);
-            need_to_reset = false;
+        // Create a VnSensor object and connect to sensor
+        VnSensor vs;
+
+        // Default baudrate variable
+        int defaultBaudrate;
+        // Run through all of the acceptable baud rates until we are connected
+        // Looping in case someone has changed the default
+        bool baudSet = false;
+        while(!baudSet){
+            // Make this variable only accessible in the while loop
+            static int i = 0;
+            defaultBaudrate = vs.supportedBaudrates()[i];
+            ROS_INFO("Connecting with default at %d", defaultBaudrate);
+            // Default response was too low and retransmit time was too long by default.
+            // They would cause errors
+            vs.setResponseTimeoutMs(1000); // Wait for up to 1000 ms for response
+            vs.setRetransmitDelayMs(50);  // Retransmit every 50 ms
+
+            // Acceptable baud rates 9600, 19200, 38400, 57600, 128000, 115200, 230400, 460800, 921600
+            // Data sheet says 128000 is a valid baud rate. It doesn't work with the VN100 so it is excluded.
+            // All other values seem to work fine.
+            try{
+                // Connect to sensor at it's default rate
+                if(defaultBaudrate != 128000 && SensorBaudrate != 128000)
+                {
+                    vs.connect(SensorPort, defaultBaudrate);
+                    // Issues a change baudrate to the VectorNav sensor and then
+                    // reconnects the attached serial port at the new baudrate.
+                    vs.changeBaudRate(SensorBaudrate);
+                    // Only makes it here once we have the default correct
+                    ROS_INFO("Connected baud rate is %d",vs.baudrate());
+                    baudSet = true;
+                }
+            }
+            // Catch all oddities
+            catch(...){
+                // Disconnect if we had the wrong default and we were connected
+                vs.disconnect();
+                ros::Duration(0.2).sleep();
+            }
+            // Increment the default iterator
+            i++;
+            // There are only 9 available data rates, if no connection
+            // made yet possibly a hardware malfunction?
+            if(i > 8)
+            {
+                break;
+            }
         }
-        ros::spinOnce(); // Need to make sure we disconnect properly. Check if all ok.
+
+        // Now we verify connection (Should be good if we made it this far)
+        if(vs.verifySensorConnectivity())
+        {
+            ROS_INFO("Device connection established");
+        }else{
+            ROS_ERROR("No device communication");
+            ROS_WARN("Please input a valid baud rate. Valid are:");
+            ROS_WARN("9600, 19200, 38400, 57600, 115200, 128000, 230400, 460800, 921600");
+            ROS_WARN("With the test IMU 128000 did not work, all others worked fine.");
+        }
+        // Query the sensor's model number.
+        string mn = vs.readModelNumber();
+        ROS_INFO("Model Number: %s", mn.c_str());
+
+        // Set the device info for passing to the packet callback function
+        UserData user_data;
+        user_data.device_family = vs.determineDeviceFamily();
+
+        // Set Data output Freq [Hz]
+        vs.writeAsyncDataOutputFrequency(async_output_rate);
+
+        // Configure binary output message
+        BinaryOutputRegister bor(
+                ASYNCMODE_PORT1,
+                SensorImuRate / async_output_rate,  // update rate [ms]
+                COMMONGROUP_QUATERNION
+                | COMMONGROUP_ANGULARRATE
+                | COMMONGROUP_POSITION
+                | COMMONGROUP_ACCEL
+                | COMMONGROUP_MAGPRES,
+                TIMEGROUP_NONE,
+                IMUGROUP_NONE,
+                GPSGROUP_NONE,
+                ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
+                INSGROUP_INSSTATUS
+                | INSGROUP_POSLLA
+                | INSGROUP_POSECEF
+                | INSGROUP_VELBODY
+                | INSGROUP_ACCELECEF);
+
+        vs.writeBinaryOutput1(bor);
+
+        // Set Data output Freq [Hz]
+        vs.writeAsyncDataOutputFrequency(async_output_rate);
+        vs.registerAsyncPacketReceivedHandler(&user_data, BinaryAsyncMessageReceived);
+
+        // You spin me right round, baby
+        // Right round like a record, baby
+        // Right round round round
+        ros::Rate loop_rate(10);
+        while (ros::ok())
+        {
+            if (need_to_reset)
+            {
+                bool wait_for_reply = true;
+                vs.reset(wait_for_reply);
+                need_to_reset = false;
+                break;
+            }
+            ros::spinOnce(); // Need to make sure we disconnect properly. Check if all ok.
+        }
+
+        // Node has been terminated
+        vs.unregisterAsyncPacketReceivedHandler();
+        ros::Duration(0.5).sleep();
+        vs.disconnect();
+        ros::Duration(0.5).sleep();
     }
 
-    // Node has been terminated
-    vs.unregisterAsyncPacketReceivedHandler();
-    ros::Duration(0.5).sleep();
-    vs.disconnect();
-    ros::Duration(0.5).sleep();
     return 0;
 }
 


### PR DESCRIPTION
This PR adds a ROS service to the vectornav IMU node that allows you to send a `reset()` command to the device.

If the device is reset, the node will re-connect the same way that it did initially and resume publishing IMU data.